### PR TITLE
Version 1.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,7 +157,7 @@
 - `Enumerable#to_recipe`が動かなくなったバグを修正．
 - `String#min_level`において，正しい答えを返さなくなったバグを修正．
 
-## 1.5.6 2022/0717
+## 1.5.6 2022/07/17
 - `String#find_lowerbound`，`String#find_upperbound`における探索刻み幅を1から1/8に変更し，コーナーケースでの精度を上昇させた．
 - `Enumerable#min_level`が，原料☆によるレベル制限を無視した値を返すことがあったバグを修正．
 - `String#find_lowerbound`や`Mgmg::IR#atk_sd` などにおいて，返り値が，分母が1の`Rational`である場合，代わりに`Integer`を返すように修正．

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,3 +156,8 @@
 ## 1.5.5 2022/07/02
 - `Enumerable#to_recipe`が動かなくなったバグを修正．
 - `String#min_level`において，正しい答えを返さなくなったバグを修正．
+
+## 1.5.6 2022/0717
+- `String#find_lowerbound`，`String#find_upperbound`における探索刻み幅を1から1/8に変更し，コーナーケースでの精度を上昇させた．
+- `Enumerable#min_level`が，原料☆によるレベル制限を無視した値を返すことがあったバグを修正．
+- `String#find_lowerbound`や`Mgmg::IR#atk_sd` などにおいて，返り値が，分母が1の`Rational`である場合，代わりに`Integer`を返すように修正．

--- a/lib/mgmg.rb
+++ b/lib/mgmg.rb
@@ -226,7 +226,7 @@ module Enumerable
 		built = recipe.build(opt:)
 		w = recipe.build(built.min_levels_max[i], opt:).weight - w if w <= 0
 		return -1 if include_outsourcing && built.weight <= w
-		return ms if build(ms, opt:).weight <= w
+		return ms if recipe.build(ms, opt:).weight <= w
 		ary = [ms]
 		4.downto(1) do |wi|
 			built.min_levels(wi).values.each do |v|

--- a/lib/mgmg/equip.rb
+++ b/lib/mgmg/equip.rb
@@ -94,13 +94,13 @@ module Mgmg
 			attack()+str()
 		end
 		def atk_sd
-			attack()+str().quo(2)+dex().quo(2)
+			( attack()+str().quo(2)+dex().quo(2) ).to_ii
 		end
 		def dex_as
-			attack().quo(2)+str().quo(2)+dex()
+			( attack().quo(2)+str().quo(2)+dex() ).to_ii
 		end
 		def mag_das
-			magic()+dex_as().quo(2)
+			( magic()+dex_as().quo(2) ).to_ii
 		end
 		def magic2
 			magic()*2
@@ -122,18 +122,18 @@ module Mgmg
 			when 6, 7
 				[magic()*2, atkstr()].max
 			when 28
-				@para.sum-((hp()+mp())*3.quo(4))
+				( @para.sum-((hp()+mp())*3.quo(4)) ).to_ii
 			else
 				ret = @para.max
 				if ret == magdef()
-					ret+magic().quo(2)
+					( ret+magic().quo(2) ).to_ii
 				else
 					ret
 				end
 			end
 		end
 		def magmag
-			magdef()+magic().quo(2)
+			( magdef()+magic().quo(2) ).to_ii
 		end
 		def fpower
 			power().to_f

--- a/lib/mgmg/ir.rb
+++ b/lib/mgmg/ir.rb
@@ -196,26 +196,26 @@ module Mgmg
 						ret *= (100+r.vec[i]).quo(100)
 					end
 				end
-				ret
+				ret.to_ii
 			end
 		end
 		def atkstr(s, ac, x=nil)
 			attack(s, ac, x)+str(s, ac, x)
 		end
 		def atk_sd(s, ac, x=nil)
-			attack(s, ac, x)+str(s, ac, x).quo(2)+dex(s, ac, x).quo(2)
+			( attack(s, ac, x)+str(s, ac, x).quo(2)+dex(s, ac, x).quo(2) ).to_ii
 		end
 		def dex_as(s, ac, x=nil)
-			attack(s, ac, x).quo(2)+str(s, ac, x).quo(2)+dex(s, ac, x)
+			( attack(s, ac, x).quo(2)+str(s, ac, x).quo(2)+dex(s, ac, x) ).to_ii
 		end
 		def mag_das(s, ac, x=nil)
-			magic(s, ac, x)+dex_as(s, ac, x).quo(2)
+			( magic(s, ac, x)+dex_as(s, ac, x).quo(2) ).to_ii
 		end
 		def magic2(s, ac, x=nil)
 			magic(s, ac, x)*2
 		end
 		def magmag(s, ac, x=nil)
-			magdef(s, ac, x)+magic(s, ac, x).quo(2)
+			( magdef(s, ac, x)+magic(s, ac, x).quo(2) ).to_ii
 		end
 		def pmdef(s, ac, x=nil)
 			[phydef(s, ac, x), magmag(s, ac, x)].min
@@ -234,7 +234,7 @@ module Mgmg
 			when 6, 7
 				[magic(s, c)*2, atkstr(s, c)].max
 			when 28
-				@para.enum_for(:sum).with_index do |e, i|
+				( @para.enum_for(:sum).with_index do |e, i|
 					x = e.evaluate3(s, a, c)
 					@rein.each do |r|
 						if r.vec[i] != 0
@@ -242,7 +242,7 @@ module Mgmg
 						end
 					end
 					x
-				end-((hp(s, a, c)+mp(s, a, c))*3.quo(4))
+				end - ((hp(s, a, c)+mp(s, a, c))*3.quo(4)) ).to_ii
 			else
 				ret = @para.map.with_index do |e, i|
 					x = e.evaluate3(s, a, c)
@@ -252,9 +252,9 @@ module Mgmg
 						end
 					end
 					x
-				end.max
+				end.max.to_ii
 				if ret == magdef(s, a, c)
-					ret+magic(s, a, c).quo(2)
+					( ret+magic(s, a, c).quo(2) ).to_ii
 				else
 					ret
 				end

--- a/lib/mgmg/poly.rb
+++ b/lib/mgmg/poly.rb
@@ -109,7 +109,7 @@ module Mgmg
 			if a == c
 				return( b == d )
 			else
-				return( (d-b).quo(a-c) )
+				return( (d-b).quo(a-c).to_ii )
 			end
 		end
 		def smith_fix(smith, fmt=nil)

--- a/lib/mgmg/search.rb
+++ b/lib/mgmg/search.rb
@@ -224,6 +224,8 @@ module Enumerable
 end
 
 module Mgmg
+	Eighth = 1.quo(8)
+	using Refiner
 	module_function def find_lowerbound(a, b, para, start, term, opt_a: Option.new, opt_b: Option.new)
 		if term <= start
 			raise ArgumentError, "start < term is needed, (start, term) = (#{start}, #{term}) are given"
@@ -245,7 +247,7 @@ module Mgmg
 		if eb < ea || ( ea == eb && opt_a.irep.para_call(para, *sca) < opt_b.irep.para_call(para, *scb) )
 			a, b, opt_a, opt_b, sca, scb, ea, eb = b, a, opt_b, opt_a, scb, sca, eb, ea
 		end
-		tag = opt_a.irep.para_call(para, *sca) + 1
+		tag = opt_a.irep.para_call(para, *sca) + Eighth
 		sca, scb = a.search(para, term, opt: opt_a), b.search(para, term, opt: opt_b)
 		ea, eb = Mgmg.exp(*sca), Mgmg.exp(*scb)
 		if ea < eb || ( ea == eb && opt_b.irep.para_call(para, *scb) < opt_a.irep.para_call(para, *sca) )
@@ -256,15 +258,15 @@ module Mgmg
 			ea, eb = Mgmg.exp(*sca), Mgmg.exp(*scb)
 			pa, pb = opt_a.irep.para_call(para, *sca), opt_b.irep.para_call(para, *scb)
 			if eb < ea
-				return [tag-1, pb]
+				return [(tag-Eighth).to_ii, pb]
 			elsif ea == eb
 				if pa < pb
-					return [tag-1, pa]
+					return [(tag-Eighth).to_ii, pa]
 				else
-					tag = pb + 1
+					tag = pb + Eighth
 				end
 			else
-				tag = pa + 1
+				tag = pa + Eighth
 			end
 		end
 		raise UnexpectedError
@@ -309,22 +311,22 @@ module Mgmg
 				pa, pb = opt_a.irep.para_call(para, *sca), opt_b.irep.para_call(para, *scb)
 				if ea < eb
 					ret = tagl
-					sca = a.search(para, pa + 1, opt: opt_a)
+					sca = a.search(para, pa + Eighth, opt: opt_a)
 					tagl = opt_a.irep.para_call(para, *sca)
 					scb = b.search(para, tagl, opt: opt_b)
 				elsif ea == eb
 					if pb < pa
 						ret = tagl
-						sca = a.search(para, pa + 1, opt: opt_a)
+						sca = a.search(para, pa + Eighth, opt: opt_a)
 						tagl = opt_a.irep.para_call(para, *sca)
 						scb = b.search(para, tagl, opt: opt_b)
 					else
-						scb = b.search(para, pb + 1, opt: opt_b)
+						scb = b.search(para, pb + Eighth, opt: opt_b)
 						tagl = opt_b.irep.para_call(para, *scb)
 						sca = a.search(para, tagl, opt: opt_a)
 					end
 				else
-					sca = a.search(para, pa + 1, opt: opt_a)
+					sca = a.search(para, pa + Eighth, opt: opt_a)
 					tagl = opt_a.irep.para_call(para, *sca)
 					scb = b.search(para, tagl, opt: opt_b)
 				end
@@ -337,11 +339,17 @@ module Mgmg
 					tagl = term
 				end
 			else
-				pa = opt_a.irep.para_call(para, *a.search(para, ret+1, opt: opt_a))
-				pb = opt_b.irep.para_call(para, *b.search(para, ret+1, opt: opt_b))
-				return [ret, [pa, pb].min]
+				pa = opt_a.irep.para_call(para, *a.search(para, ret+Eighth, opt: opt_a))
+				pb = opt_b.irep.para_call(para, *b.search(para, ret+Eighth, opt: opt_b))
+				return [ret.to_ii, [pa, pb].min]
 			end
 		end
 		raise UnexpectedError
+	end
+	
+	module_function def find_lubounds(a, b, para, lower, upper, opt_a: Mgmg::Option.new, opt_b: Mgmg::Option.new)
+		xl, yl = find_lowerbound(a, b, para, lower, upper, opt_a:, opt_b:)
+		xu, yu = find_upperbound(a, b, para, upper, lower, opt_a:, opt_b:)
+		[xl, yl, xu, yu]
 	end
 end

--- a/lib/mgmg/utils.rb
+++ b/lib/mgmg/utils.rb
@@ -13,6 +13,8 @@ module Mgmg
 					self.div(other)
 				end
 			end
+			
+			alias :to_ii :itself
 		end
 		refine Float do
 			alias :cdiv :quo # Floatの場合は普通の割り算
@@ -53,6 +55,14 @@ module Mgmg
 					self.numerator.comma3
 				else
 					self.to_f.comma3
+				end
+			end
+			
+			def to_ii
+				if self.denominator == 1
+					self.numerator
+				else
+					self
 				end
 			end
 		end

--- a/lib/mgmg/version.rb
+++ b/lib/mgmg/version.rb
@@ -1,3 +1,3 @@
 module Mgmg
-	VERSION = "1.5.5"
+	VERSION = "1.5.6"
 end


### PR DESCRIPTION
- `String#find_lowerbound`，`String#find_upperbound`における探索刻み幅を1から1/8に変更し，コーナーケースでの精度を上昇させた．
- `Enumerable#min_level`が，原料☆によるレベル制限を無視した値を返すことがあったバグを修正．
- `String#find_lowerbound`や`Mgmg::IR#atk_sd` などにおいて，返り値が，分母が1の`Rational`である場合，代わりに`Integer`を返すように修正．