### PR TITLE
Version 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,3 +165,7 @@
 ## 1.5.7 2022/10/15
 - 経験値上限を指定して，目標パラメータを最大化する製作Lvを返す`Mgmg::Recipe#find_max`を追加．
 - `Mgmg::Recipe#search`において，解の経験値が`cut_exp`ちょうどの場合に例外となっていたバグを修正．
+
+## 1.6.0 2022/10/18
+- `Mgmg.#find_upperbound`のアルゴリズムを改善し，探索下限目標値の引数を削除．
+- `Enumerable#search`，`Enumerable#find_max`が正しい解を返さない場合があったバグを修正．

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,10 @@
 - `String#min_level`において，正しい答えを返さなくなったバグを修正．
 
 ## 1.5.6 2022/07/17
-- `String#find_lowerbound`，`String#find_upperbound`における探索刻み幅を1から1/8に変更し，コーナーケースでの精度を上昇させた．
+- `Mgmg.#find_lowerbound`，`Mgmg.#find_upperbound`における探索刻み幅を1から1/8に変更し，コーナーケースでの精度を上昇させた．
 - `Enumerable#min_level`が，原料☆によるレベル制限を無視した値を返すことがあったバグを修正．
-- `String#find_lowerbound`や`Mgmg::IR#atk_sd` などにおいて，返り値が，分母が1の`Rational`である場合，代わりに`Integer`を返すように修正．
+- `Mgmg.#find_lowerbound`や`Mgmg::IR#atk_sd` などにおいて，返り値が，分母が1の`Rational`である場合，代わりに`Integer`を返すように修正．
+
+## 1.5.7 2022/10/15
+- 経験値上限を指定して，目標パラメータを最大化する製作Lvを返す`Mgmg::Recipe#find_max`を追加．
+- `Mgmg::Recipe#search`において，解の経験値が`cut_exp`ちょうどの場合に例外となっていたバグを修正．

--- a/lib/mgmg/option.rb
+++ b/lib/mgmg/option.rb
@@ -2,7 +2,7 @@ module Mgmg
 	class Option
 		Defaults = {
 			left_associative: true, include_system_equips: true,
-			smith_max: 10000, armor_max: 10000, comp_max: 10000
+			smith_max: 10_000, armor_max: 10_000, comp_max: 10_000
 		}
 		def initialize(
 			left_associative: Defaults[:left_associative],

--- a/lib/mgmg/recipe.rb
+++ b/lib/mgmg/recipe.rb
@@ -93,6 +93,10 @@ module Mgmg
 			opt = temp_opt(**kw)
 			@recipe.search(para, target, opt:)
 		end
+		def find_max(max_exp, para: @para, **kw)
+			opt = temp_opt(**kw)
+			@recipe.find_max(para, max_exp, opt:)
+		end
 		private def correct_level(s, ac, x, opt)
 			if s.nil?
 				if x.equal?(false)

--- a/lib/mgmg/search.rb
+++ b/lib/mgmg/search.rb
@@ -79,15 +79,27 @@ class String
 		ret
 	end
 	
+	private def minimize_smith(para, smith, comp, cur, opt)
+		(smith-1).downto(opt.smith_min) do |s|
+			foo = opt.irep.para_call(para, s, comp)
+			if cur == foo
+				smith = s
+			else
+				break
+			end
+		end
+		smith
+	end
 	def find_max(para, max_exp, opt: Mgmg::Option.new)
 		opt = opt.dup.set_default(self)
 		exp = Mgmg.exp(opt.smith_min, opt.comp_min)
 		raise Mgmg::SearchCutException, "the recipe requires #{exp.comma3} experiment points, which exceeds given max_exp=#{max_exp.comma3}" if max_exp < exp
 		ret = [Mgmg.invexp2(max_exp, opt.comp_min), opt.comp_min]
 		max = opt.irep.para_call(para, *ret)
-		(opt.comp_min+1).step(Mgmg.invexp2c(max_exp, opt.smith_min), opt.step) do |comp|
+		(opt.comp_min+1).upto(Mgmg.invexp2c(max_exp, opt.smith_min)) do |comp|
 			smith = Mgmg.invexp2(max_exp, comp)
 			cur = opt.irep.para_call(para, smith, comp)
+			smith = minimize_smith(para, smith, comp, cur, opt) if max <= cur
 			ret, max = [smith, comp], cur if ( max < cur || ( max == cur && Mgmg.exp(smith, comp) < Mgmg.exp(*ret) ) )
 		end
 		ret
@@ -211,20 +223,79 @@ module Enumerable
 		end
 		opt.comp_max
 	end
+	private def search_aonly(para, target, opt: Mgmg::Option.new)
+		opt_nocut = opt.dup; opt_nocut.cut_exp = Float::INFINITY
+		opt.armor_max = armor_search(para, target, -1, opt.comp_min, opt: opt_nocut)
+		opt.armor_min = armor_search(para, target, -1, opt.comp_max, opt: opt_nocut)
+		raise Mgmg::SearchCutException if opt.cut_exp < Mgmg.exp(opt.armor_min, opt.comp_min)
+		opt.comp_max = comp_search(para, target, -1, opt.armor_min, opt:)
+		ret = nil
+		exp = Mgmg.exp(opt.armor_min, opt.comp_max)
+		opt.cut_exp, ret = exp, [-1, opt.armor_min, opt.comp_max] if exp <= opt.cut_exp
+		exp = Mgmg.exp(opt.armor_max, opt.comp_min)
+		opt.cut_exp, ret = exp, [-1, opt.armor_max, opt.comp_min] if ( exp < opt.cut_exp || (ret.nil? && exp==opt.cut_exp) )
+		(opt.comp_min+opt.step).step(opt.comp_max-1, opt.step) do |comp|
+			break if opt.cut_exp < Mgmg.exp(opt.armor_min, comp)
+			armor = armor_search(para, target, -1, comp, opt:)
+			exp = Mgmg.exp(armor, comp)
+			if exp < opt.cut_exp
+				opt.cut_exp, ret = exp, [-1, armor, comp]
+			elsif exp == opt.cut_exp
+				if ret.nil? or opt.irep.para_call(para, *ret) < opt.irep.para_call(para, -1, armor, comp) then
+					ret = [-1, armor, comp]
+				end
+			end
+		rescue Mgmg::SearchCutException
+		end
+		if ret.nil?
+			max = opt.irep.para_call(para, *find_max(para, opt.cut_exp, opt:))
+			raise Mgmg::SearchCutException, "the maximum output with given cut_exp=#{opt.cut_exp.comma3} is #{max.comma3}, which does not reach given target=#{target.comma3}"
+		end
+		ret
+	end
+	private def search_sonly(para, target, opt: Mgmg::Option.new)
+		opt_nocut = opt.dup; opt_nocut.cut_exp = Float::INFINITY
+		opt.smith_max = smith_search(para, target, -1, opt.comp_min, opt: opt_nocut)
+		opt.smith_min = smith_search(para, target, -1, opt.comp_max, opt: opt_nocut)
+		raise Mgmg::SearchCutException if opt.cut_exp < Mgmg.exp(opt.smith_min, opt.comp_min)
+		opt.comp_max = comp_search(para, target, opt.smith_min, -1, opt:)
+		ret = nil
+		exp = Mgmg.exp(opt.smith_min, opt.comp_max)
+		opt.cut_exp, ret = exp, [opt.smith_min, -1, opt.comp_max] if exp <= opt.cut_exp
+		exp = Mgmg.exp(opt.smith_max, opt.comp_min)
+		opt.cut_exp, ret = exp, [opt.smith_max, -1, opt.comp_min] if ( exp < opt.cut_exp || (ret.nil? && exp==opt.cut_exp) )
+		(opt.comp_min+opt.step).step(opt.comp_max-1, opt.step) do |comp|
+			break if opt.cut_exp < Mgmg.exp(opt.smith_min, comp)
+			smith = smith_search(para, target, -1, comp, opt:)
+			exp = Mgmg.exp(smith, comp)
+			if exp < opt.cut_exp
+				opt.cut_exp, ret = exp, [smith, -1, comp]
+			elsif exp == opt.cut_exp
+				if ret.nil? or opt.irep.para_call(para, *ret) < opt.irep.para_call(para, smith, -1, comp) then
+					ret = [smith, -1, comp]
+				end
+			end
+		rescue Mgmg::SearchCutException
+		end
+		if ret.nil?
+			max = opt.irep.para_call(para, *find_max(para, opt.cut_exp, opt:))
+			raise Mgmg::SearchCutException, "the maximum output with given cut_exp=#{opt.cut_exp.comma3} is #{max.comma3}, which does not reach given target=#{target.comma3}"
+		end
+		ret
+	end
 	def search(para, target, opt: Mgmg::Option.new)
 		opt = opt.dup.set_default(self)
 		opt.comp_min = comp_search(para, target, opt.smith_max, opt.armor_max, opt:)
 		opt_nocut = opt.dup; opt_nocut.cut_exp = Float::INFINITY
-		opt.smith_max, opt.armor_max = sa_search(para, target, opt.comp_min, opt: opt_nocut)
-		opt.smith_min, opt.armor_min = sa_search(para, target, opt.comp_max, opt: opt_nocut)
+		opt.smith_max = smith_search(para, target, opt.armor_min, opt.comp_min, opt: opt_nocut) rescue ( return search_aonly(para, target, opt:) )
+		opt.armor_max = armor_search(para, target, opt.smith_min, opt.comp_min, opt: opt_nocut) rescue ( return search_sonly(para, target, opt:) )
+		opt.smith_min = smith_search(para, target, opt.armor_max, opt.comp_max, opt: opt_nocut)
+		opt.armor_min = armor_search(para, target, opt.smith_max, opt.comp_max, opt: opt_nocut)
 		raise Mgmg::SearchCutException if opt.cut_exp < Mgmg.exp(opt.smith_min, opt.armor_min, opt.comp_min)
 		opt.comp_max = comp_search(para, target, opt.smith_min, opt.armor_min, opt:)
-		ret = nil
 		exp = Mgmg.exp(opt.smith_min, opt.armor_min, opt.comp_max)
 		opt.cut_exp, ret = exp, [opt.smith_min, opt.armor_min,opt. comp_max] if exp <= opt.cut_exp
-		exp = Mgmg.exp(opt.smith_max, opt.armor_max, opt.comp_min)
-		opt.cut_exp, ret = exp, [opt.smith_max, opt.armor_max, opt.comp_min] if ( exp < opt.cut_exp || (ret.nil? && exp==opt.cut_exp) )
-		(opt.comp_min+1).upto(opt.comp_max-1) do |comp|
+		(opt.comp_min).upto(opt.comp_max-1) do |comp|
 			break if opt.cut_exp < Mgmg.exp(opt.smith_min, opt.armor_min, comp)
 			smith, armor = sa_search(para, target, comp, opt:)
 			exp = Mgmg.exp(smith, armor, comp)
@@ -244,17 +315,31 @@ module Enumerable
 		ret
 	end
 	
+	private def minimize_smith(para, smith, armor, comp, cur, opt)
+		return -1 if opt.smith_min < 0
+		(smith-1).downto(opt.smith_min) do |s|
+			foo = opt.irep.para_call(para, s, armor, comp)
+			if cur == foo
+				smith = s
+			else
+				break
+			end
+		end
+		smith
+	end
 	def find_max(para, max_exp, opt: Mgmg::Option.new)
 		opt = opt.dup.set_default(self)
 		exp = Mgmg.exp(opt.smith_min, opt.armor_min, opt.comp_min)
 		raise Mgmg::SearchCutException, "the recipe requires #{exp.comma3} experiment points, which exceeds given max_exp=#{max_exp.comma3}" if max_exp < exp
 		ret = [Mgmg.invexp3(max_exp, opt.armor_min, opt.comp_min), opt.armor_min, opt.comp_min]
 		max = opt.irep.para_call(para, *ret)
-		(opt.comp_min+1).step(Mgmg.invexp3c(max_exp, opt.smith_min, opt.armor_min), opt.step) do |comp|
+		(opt.comp_min).step(Mgmg.invexp3c(max_exp, opt.smith_min, opt.armor_min), opt.step) do |comp|
 			opt.armor_min.upto(Mgmg.invexp3(max_exp, opt.smith_min, comp)) do |armor|
 				smith = Mgmg.invexp3(max_exp, armor, comp)
 				cur = opt.irep.para_call(para, smith, armor, comp)
+				smith = minimize_smith(para, smith, armor, comp, cur, opt) if max <= cur
 				ret, max = [smith, armor, comp], cur if ( max < cur || ( max == cur && Mgmg.exp(smith, armor, comp) < Mgmg.exp(*ret) ) )
+				break if armor < 0
 			end
 		end
 		ret
@@ -281,38 +366,42 @@ module Mgmg
 		end
 		sca, scb = a.search(para, start, opt: opt_a), b.search(para, start, opt: opt_b)
 		ea, eb = Mgmg.exp(*sca), Mgmg.exp(*scb)
-		if eb < ea || ( ea == eb && opt_a.irep.para_call(para, *sca) < opt_b.irep.para_call(para, *scb) )
+		pa, pb = opt_a.irep.para_call(para, *sca), opt_b.irep.para_call(para, *scb)
+		if eb < ea || ( ea == eb && pa < pb )
 			a, b, opt_a, opt_b, sca, scb, ea, eb = b, a, opt_b, opt_a, scb, sca, eb, ea
 		end
-		tag = opt_a.irep.para_call(para, *sca) + Eighth
-		sca, scb = a.search(para, term, opt: opt_a), b.search(para, term, opt: opt_b)
-		ea, eb = Mgmg.exp(*sca), Mgmg.exp(*scb)
-		if ea < eb || ( ea == eb && opt_b.irep.para_call(para, *scb) < opt_a.irep.para_call(para, *sca) )
-			raise Mgmg::SearchCutException
-		end
-		while tag < term
-			sca, scb = a.search(para, tag, opt: opt_a), b.search(para, tag, opt: opt_b)
-			ea, eb = Mgmg.exp(*sca), Mgmg.exp(*scb)
-			pa, pb = opt_a.irep.para_call(para, *sca), opt_b.irep.para_call(para, *scb)
-			if eb < ea
-				return [(tag-Eighth).to_ii, pb]
-			elsif ea == eb
-				if pa < pb
-					return [(tag-Eighth).to_ii, pa]
-				else
-					tag = pb + Eighth
-				end
-			else
+		
+		loop do
+			loop do
+				foo = a.find_max(para, eb, opt: opt_a)
+				break if sca == foo
+				sca, pa = foo, opt_a.irep.para_call(para, *foo)
+				scb = b.search(para, pa, opt: opt_b)
+				foo = Mgmg.exp(*scb)
+				break if eb == foo
+				eb = foo
+			end
+			ea = Mgmg.exp(*sca)
+			while ea<=eb
 				tag = pa + Eighth
+				raise Mgmg::SearchCutException, "given recipes are never reversed from start target=#{start.comma3} until term target=#{term.comma3}" if term < tag
+				sca, scb = a.search(para, tag, opt: opt_a), b.search(para, tag, opt: opt_b)
+				ea, eb = Mgmg.exp(*sca), Mgmg.exp(*scb)
+				pa, pb = opt_a.irep.para_call(para, *sca), opt_b.irep.para_call(para, *scb)
+				break if ea == eb && pa < pb
+			end
+			if eb < ea || ( ea == eb && pa < pb )
+				until ea < eb || ( ea == eb && pb < pa )
+					sca = a.find_max(para, ea-1, opt: opt_a)
+					ea, pa = Mgmg.exp(*sca), opt_a.irep.para_call(para, *sca)
+				end
+				return [pa, pb]
 			end
 		end
 		raise UnexpectedError
 	end
 	
-	module_function def find_upperbound(a, b, para, start, term, opt_a: Option.new, opt_b: Option.new)
-		if start <= term
-			raise ArgumentError, "term < start is needed, (start, term) = (#{start}, #{term}) are given"
-		end
+	module_function def find_upperbound(a, b, para, start, opt_a: Option.new, opt_b: Option.new)
 		if a.kind_of?(Recipe)
 			opt_a = a.option.dup
 			a = a.recipe
@@ -327,58 +416,53 @@ module Mgmg
 		end
 		sca, scb = a.search(para, start, opt: opt_a), b.search(para, start, opt: opt_b)
 		ea, eb = Mgmg.exp(*sca), Mgmg.exp(*scb)
-		if ea < eb || ( ea == eb && opt_b.irep.para_call(para, *scb) < opt_a.irep.para_call(para, *sca) )
+		pa, pb = opt_a.irep.para_call(para, *sca), opt_b.irep.para_call(para, *scb)
+		if ea < eb || ( ea == eb && pb < pa )
 			a, b, opt_a, opt_b, sca, scb, ea, eb = b, a, opt_b, opt_a, scb, sca, eb, ea
 		end
-		tagu = opt_a.irep.para_call(para, *sca)
-		sca[-1] -= 2
-		tagl = opt_a.irep.para_call(para, *sca)
-		sca, scb = a.search(para, term, opt: opt_a), b.search(para, term, opt: opt_b)
-		ea, eb = Mgmg.exp(*sca), Mgmg.exp(*scb)
-		if eb < ea || ( ea == eb && opt_a.irep.para_call(para, *sca) < opt_b.irep.para_call(para, *scb) )
-			raise Mgmg::SearchCutException
-		end
-		while term < tagu
-			ret = nil
-			sca = a.search(para, tagl, opt: opt_a)
-			next_tagu, next_sca = tagl, sca
-			scb = b.search(para, tagl, opt: opt_b)
-			while tagl < tagu
+		
+		loop do
+			loop do
+				foo = a.find_max(para, eb, opt: opt_a)
+				break if sca == foo
+				sca, pa = foo, opt_a.irep.para_call(para, *foo)
+				scb = b.search(para, pa, opt: opt_b)
+				foo = Mgmg.exp(*scb)
+				break if eb == foo
+				eb = foo
+			end
+			ea = Mgmg.exp(*sca)
+			while ea==eb do
+				res = 0
+				begin
+					sca = a.find_max(para, ea-1, opt: opt_a)
+				rescue Mgmg::SearchCutException
+					res += 1
+				end
+				begin
+					scb = b.find_max(para, eb-1, opt: opt_b)
+				rescue Mgmg::SearchCutException
+					res += 1
+				end
 				ea, eb = Mgmg.exp(*sca), Mgmg.exp(*scb)
 				pa, pb = opt_a.irep.para_call(para, *sca), opt_b.irep.para_call(para, *scb)
-				if ea < eb
-					ret = tagl
-					sca = a.search(para, pa + Eighth, opt: opt_a)
-					tagl = opt_a.irep.para_call(para, *sca)
-					scb = b.search(para, tagl, opt: opt_b)
-				elsif ea == eb
-					if pb < pa
-						ret = tagl
-						sca = a.search(para, pa + Eighth, opt: opt_a)
-						tagl = opt_a.irep.para_call(para, *sca)
-						scb = b.search(para, tagl, opt: opt_b)
-					else
-						scb = b.search(para, pb + Eighth, opt: opt_b)
-						tagl = opt_b.irep.para_call(para, *scb)
-						sca = a.search(para, tagl, opt: opt_a)
+				if ea < eb || ( ea == eb && pb < pa )
+					until pa < pb
+						scb = b.search(para, pb+Eighth, opt: opt_b)
+						pb = opt_b.irep.para_call(para, *scb)
 					end
-				else
-					sca = a.search(para, pa + Eighth, opt: opt_a)
-					tagl = opt_a.irep.para_call(para, *sca)
-					scb = b.search(para, tagl, opt: opt_b)
+					return [pa, pb]
+				elsif res == 2
+					raise Mgmg::SearchCutException, "given recipes are never reversed from the start target=#{start.comma3} until #{pa.comma3}"
 				end
 			end
-			if ret.nil?
-				tagu = next_tagu
-				next_sca[-1] -= 2
-				tagl = opt_a.irep.para_call(para, *next_sca)
-				if tagl == tagu
-					tagl = term
+			if ea < eb
+				pb = opt_b.irep.para_call(para, *scb)
+				until pa < pb
+					scb = b.search(para, pb+Eighth, opt: opt_b)
+					pb = opt_b.irep.para_call(para, *scb)
 				end
-			else
-				pa = opt_a.irep.para_call(para, *a.search(para, ret+Eighth, opt: opt_a))
-				pb = opt_b.irep.para_call(para, *b.search(para, ret+Eighth, opt: opt_b))
-				return [ret.to_ii, [pa, pb].min]
+				return [pa, pb]
 			end
 		end
 		raise UnexpectedError
@@ -386,7 +470,32 @@ module Mgmg
 	
 	module_function def find_lubounds(a, b, para, lower, upper, opt_a: Mgmg::Option.new, opt_b: Mgmg::Option.new)
 		xl, yl = find_lowerbound(a, b, para, lower, upper, opt_a:, opt_b:)
-		xu, yu = find_upperbound(a, b, para, upper, lower, opt_a:, opt_b:)
+		xu, yu = find_upperbound(a, b, para, upper, opt_a:, opt_b:)
 		[xl, yl, xu, yu]
+	end
+	module_function def find_lubounds2(a, b, para, lower, upper, opt_a: Mgmg::Option.new, opt_b: Mgmg::Option.new)
+		xl, yl, xu, yu = find_lubounds(a, b, para, lower, upper, opt_a: Mgmg::Option.new, opt_b: Mgmg::Option.new)
+		if a.kind_of?(Recipe)
+			opt_a = a.option.dup
+			a = a.recipe
+		else
+			opt_a = opt_a.dup.set_default(a)
+		end
+		if b.kind_of?(Recipe)
+			opt_b = b.option.dup
+			b = b.recipe
+		else
+			opt_b = opt_b.dup.set_default(b)
+		end
+		sca, scb = a.search(para, lower, opt: opt_a), b.search(para, lower, opt: opt_b)
+		ea, eb = Mgmg.exp(*sca), Mgmg.exp(*scb)
+		pa, pb = opt_a.irep.para_call(para, *sca), opt_b.irep.para_call(para, *scb)
+		if eb < ea || ( ea == eb && pa < pb )
+			a, b, opt_a, opt_b, sca, scb, ea, eb = b, a, opt_b, opt_a, scb, sca, eb, ea
+		end
+		sca, scb = a.search(para, xl, opt: opt_a), b.search(para, yu, opt: opt_b)
+		ea, eb = Mgmg.exp(*sca), Mgmg.exp(*scb)
+		pa, pb = opt_a.irep.para_call(para, *sca), opt_b.irep.para_call(para, *scb)
+		[sca, ea, pa, scb, eb, pb]
 	end
 end

--- a/lib/mgmg/utils.rb
+++ b/lib/mgmg/utils.rb
@@ -158,7 +158,11 @@ module Mgmg
 		end
 	end
 	module_function def invexp2(exp, comp)
-		ret = Math.sqrt(exp - (2*((comp-1)**2)) - 3).floor + 2
+		begin
+			ret = Math.sqrt(exp - (2*((comp-1)**2)) - 3).floor + 2
+		rescue Math::DomainError
+			return -1
+		end
 		if Mgmg.exp(ret, comp) <= exp
 			ret
 		else
@@ -166,7 +170,11 @@ module Mgmg
 		end
 	end
 	module_function def invexp2c(exp, s)
-		ret = Math.sqrt((exp - (((s-1)**2)) - 3).quo(2)).floor + 2
+		begin
+			ret = Math.sqrt((exp - (((s-1)**2)) - 3).quo(2)).floor + 2
+		rescue Math::DomainError
+			return -1
+		end
 		if Mgmg.exp(s, ret) <= exp
 			ret
 		else
@@ -174,7 +182,12 @@ module Mgmg
 		end
 	end
 	module_function def invexp3(exp, sa, comp)
-		ret = Math.sqrt(exp - ((sa-1)**2) - (2*((comp-1)**2)) - 4).floor + 2
+		return invexp2(exp, comp) if sa < 0
+		begin
+			ret = Math.sqrt(exp - ((sa-1)**2) - (2*((comp-1)**2)) - 4).floor + 2
+		rescue Math::DomainError
+			return -1
+		end
 		if Mgmg.exp(ret, sa, comp) <= exp
 			ret
 		else
@@ -182,7 +195,16 @@ module Mgmg
 		end
 	end
 	module_function def invexp3c(exp, smith, armor)
-		ret = Math.sqrt((exp - ((smith-1)**2) - ((armor-1)**2) - 4).quo(2)).floor + 2
+		if smith < 0
+			return invexp2c(exp, armor)
+		elsif armor < 0
+			return invexp2c(exp, smith)
+		end
+		begin
+			ret = Math.sqrt((exp - ((smith-1)**2) - ((armor-1)**2) - 4).quo(2)).floor + 2
+		rescue Math::DomainError
+			return -1
+		end
 		if Mgmg.exp(smith, armor, ret) <= exp
 			ret
 		else

--- a/lib/mgmg/utils.rb
+++ b/lib/mgmg/utils.rb
@@ -158,10 +158,36 @@ module Mgmg
 		end
 	end
 	module_function def invexp2(exp, comp)
-		Math.sqrt(exp - (2*((comp-1)**2)) - 3).round + 1
+		ret = Math.sqrt(exp - (2*((comp-1)**2)) - 3).floor + 2
+		if Mgmg.exp(ret, comp) <= exp
+			ret
+		else
+			ret-1
+		end
+	end
+	module_function def invexp2c(exp, s)
+		ret = Math.sqrt((exp - (((s-1)**2)) - 3).quo(2)).floor + 2
+		if Mgmg.exp(s, ret) <= exp
+			ret
+		else
+			ret-1
+		end
 	end
 	module_function def invexp3(exp, sa, comp)
-		Math.sqrt(exp - ((sa-1)**2) - (2*((comp-1)**2)) - 4).round + 1
+		ret = Math.sqrt(exp - ((sa-1)**2) - (2*((comp-1)**2)) - 4).floor + 2
+		if Mgmg.exp(ret, sa, comp) <= exp
+			ret
+		else
+			ret-1
+		end
+	end
+	module_function def invexp3c(exp, smith, armor)
+		ret = Math.sqrt((exp - ((smith-1)**2) - ((armor-1)**2) - 4).quo(2)).floor + 2
+		if Mgmg.exp(smith, armor, ret) <= exp
+			ret
+		else
+			ret-1
+		end
 	end
 	module_function def clear_cache
 		CacheMLS.clear; Equip::Cache.clear; Equip::CacheML.clear; TPolynomial::Cache.clear; IR::Cache.clear

--- a/lib/mgmg/version.rb
+++ b/lib/mgmg/version.rb
@@ -1,3 +1,3 @@
 module Mgmg
-	VERSION = "1.5.6"
+	VERSION = "1.5.7"
 end

--- a/lib/mgmg/version.rb
+++ b/lib/mgmg/version.rb
@@ -1,3 +1,3 @@
 module Mgmg
-	VERSION = "1.5.7"
+	VERSION = "1.6.0"
 end

--- a/reference.md
+++ b/reference.md
@@ -161,7 +161,7 @@
 
 `opt_a`，`opt_b`には，それぞれ`a`と`b`に関するオプションパラメータを指定します．`smith_min`，`armor_min`，`min_smith`，`left_associative`，`reinforcement`，`irep`を使用します．
 
-## `Mgmg.#find_upperbound(a, b, para, start, term, opt_a: Mgmg.option(), opt_b: Mgmg.option())`
+## `Mgmg.#find_upperbound(a, b, para, start, opt_a: Mgmg.option(), opt_b: Mgmg.option())`
 `Mgmg.#find_lowerbound`とは逆に，目標値を下げながら，優劣が逆転する最大の目標値を探索し，返します．返り値は`[逆転する最大目標値, 逆転前の最小para値]`です．目標値が，前者よりも少しでも大きいと逆転が起こらず(逆転する目標値の上限)，少しだけ大きい時の`para`値が後者になります．
 
 `opt_a`，`opt_b`は，`Mgmg.#find_lowerbound`と同様です．
@@ -455,7 +455,7 @@ alias として`*`があるほか`scalar(1.quo(value))`として`quo`，`/`，`s
 |smith_min|`recipe.min_level(target_weight)`|非対応|鍛冶Lvに関する探索範囲の最小値|`String#search`など|
 |armor_min|`recipe.min_level(*target_weight)[1]`|非対応|防具製作Lvに関する探索範囲の最小値|`Enumerable#search`など．`String`系では代わりに`smith_min`を使う|
 |comp_min|`recipe.min_comp`|非対応|道具製作Lvに関する探索範囲の最小値|`String#search`など|
-|smith_max, armor_max, comp_max|`10000`|対応|各製作Lvの探索範囲の最大値|`String#search`など|
+|smith_max, armor_max, comp_max|`10,000`|対応|各製作Lvの探索範囲の最大値|`String#search`など|
 |target_weight|`0`|非対応|`smith_min`のデフォルト値計算に使う目標重量|`String#search`など|
 |step|`1`|非対応|探索時において道具製作Lvを動かす幅|`String#search`など|
 |magdef_maximize|`true`|非対応|目標を魔防最大(真)かコスト最小(偽)にするためのスイッチ|`String#phydef_optimize`|

--- a/reference.md
+++ b/reference.md
@@ -130,7 +130,7 @@
 `opt`は，`comp_min`，`comp_max`，`left_associative`，`reinforcement`，`irep`を使用します．
 
 ## `String#search(para, target, opt: Mgmg.option())`
-`c_min=comp_search(para, target, opt.smith_max, opt: opt)` から `c_max=comp_search(para, target, opt.smith_min, opt: opt)` まで，`opt.step`ずつ動かして，
+道具製作Lvを `c_min=comp_search(para, target, opt.smith_max, opt: opt)` から `c_max=comp_search(para, target, opt.smith_min, opt: opt)` まで，`opt.step`ずつ動かして，
 `smith_search`を行い，その過程で得られた最小経験値の鍛冶・防具製作Lvと道具製作Lvからなる配列を返します．
 レシピ中の，対象パラメータの種別値がすべて奇数，または全て偶数であるなら，`opt.step`を`2`にしても探索すべき範囲を網羅できます．
 その他は`String#smith_seach`と同様です．
@@ -139,11 +139,17 @@
 
 ## `Enumerable#search(para, target, opt: Mgmg.option())`
 複数装備の組について，`para`の値が`target`以上となる最小経験値の`[鍛冶Lv，防具製作Lv，道具製作Lv]`を返します．
-武器のみなら防具製作Lvは`0`，防具のみなら鍛冶Lvは`0`，合成なしなら道具製作Lvは`0`となります．
+武器のみなら防具製作Lvは`-1`，防具のみなら鍛冶Lvは`-1`，合成なしなら道具製作Lvは`0`となります．
 
 `opt.smith_min`および`opt.armor_min`のデフォルト値は，武器・防具の各総重量を`opt.target_weight`で製作するのに必要な鍛冶・防具製作Lv (`self.min_level(*opt.target_weight)`)です．`opt.target_weight`には2要素からなる配列を指定しますが，整数が与えられた場合，それを2つ並べた配列と同等のものとして扱います．合計重量を指定することにはならないので注意してください．`opt.target_weight`のデフォルト値は`0`です．
 
 その他は，`String#smith_seach`と同様です．
+
+## `String#find_max(para, max_exp, opt: Mgmg.option())`
+経験値の合計が`max_exp`以下の範囲で，`para`の値が最大となる鍛冶・防具製作Lvと道具製作Lvからなる配列を返します．`para`の値が最大となる組が複数存在する場合，経験値が小さい方が優先されます．
+
+## `Enumerable#find_max(para, max_exp, opt: Mgmg.option())`
+複数装備の組について，経験値の合計が`max_exp`以下の範囲で，`para`の値が最大となる鍛冶Lv，防具製作Lv，道具製作Lvからなる配列を返します．`para`の値が最大となる組が複数存在する場合，経験値が小さい方が優先されます．
 
 ## `Mgmg.#find_lowerbound(a, b, para, start, term, opt_a: Mgmg.option(), opt_b: Mgmg.option())`
 レシピ`a`とレシピ`b`について，`para`の値を目標値以上にする最小経験値の組において，目標値`start`における優劣が逆転する目標値の下限を探索し，返します．
@@ -481,6 +487,9 @@ alias として`*`があるほか`scalar(1.quo(value))`として`quo`，`/`，`s
 
 ## `Mgmg::Recipe#search(target, para: self.para, **kw)`
 `self.recipe.search`を呼び出して返します．注目パラメータはセットされたものを自動的に渡しますが，別のパラメータを使いたい場合，キーワード引数で指定します．その他のキーワード引数を与えた場合，オプションのうち，与えられたパラメータのみ一時的に上書きします．
+
+## `Mgmg::Recipe#find_max(max_exp, para: self.para, **kw)`
+`self.recipe.find_max`を呼び出して返します．注目パラメータはセットされたものを自動的に渡しますが，別のパラメータを使いたい場合，キーワード引数で指定します．その他のキーワード引数を与えた場合，オプションのうち，与えられたパラメータのみ一時的に上書きします．
 
 ## `Mgmg::Recipe#min_level(w=self.option.target_weight, include_outsourcing=false)`
 `self.recipe.min_level(w, include_outsourcing)`を返します．`w`のデフォルトパラメータが`target_weight`になっている以外は`String#min_level`または`Enumerable#min_level`と同じです．


### PR DESCRIPTION
- `Mgmg.#find_upperbound`のアルゴリズムを改善し，探索下限目標値の引数を削除．
- `Enumerable#search`，`Enumerable#find_max`が正しい解を返さない場合があったバグを修正．