### PR TITLE
Version 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,3 +169,8 @@
 ## 1.6.0 2022/10/18
 - `Mgmg.#find_upperbound`のアルゴリズムを改善し，探索下限目標値の引数を削除．
 - `Enumerable#search`，`Enumerable#find_max`が正しい解を返さない場合があったバグを修正．
+
+## 1.6.1 2022/10/21
+- `Mgmg.#find_lowerbound`，`Mgmg.#find_upperbound`において，同値レシピを指定した場合などを例外とするように修正．
+- `Enumerable#to_recipe`にも`allow_over20`キーワード引数を導入し，デフォルトで☆20を超えるレシピを含む場合に例外とするように修正．
+- 実効HP(最大HP+腕力)を表す`Mgmg::Equip#hs`を追加．

--- a/lib/mgmg.rb
+++ b/lib/mgmg.rb
@@ -89,6 +89,8 @@ class String
 			pd = self.poly(:phydef, opt:)
 			md = self.poly(:magmag, opt:)
 			pd <= md ? pd : md
+		when :hs
+			self.poly(:hp, opt:) + self.poly(:str, opt:)
 		when :cost
 			if opt.include_system_equips and Mgmg::SystemEquip.has_key?(self) then
 				return Mgmg::TPolynomial.new(Mgmg::Mat.new(1, 1, 0.quo(1)), 28, 0, 12, 12)
@@ -140,7 +142,13 @@ class String
 end
 module Enumerable
 	using Mgmg::Refiner
-	def to_recipe(para=:power, **kw)
+	def to_recipe(para=:power, allow_over20: false, **kw)
+		unless allow_over20
+			self.each do |e|
+				foo = e.build(-1).star
+				raise Mgmg::Over20Error, foo if 20 < foo
+			end
+		end
 		Mgmg::Recipe.new(self, para, **kw)
 	end
 	def build(smith=-1, armor=smith, comp=armor.tap{armor=smith}, opt: Mgmg::Option.new)

--- a/lib/mgmg/equip.rb
+++ b/lib/mgmg/equip.rb
@@ -105,6 +105,9 @@ module Mgmg
 		def magic2
 			magic()*2
 		end
+		def hs
+			hp()+str()
+		end
 		[:fire, :earth, :water].each.with_index do |s, i|
 			define_method(s){ @element[i] }
 		end

--- a/lib/mgmg/ir.rb
+++ b/lib/mgmg/ir.rb
@@ -220,6 +220,9 @@ module Mgmg
 		def pmdef(s, ac, x=nil)
 			[phydef(s, ac, x), magmag(s, ac, x)].min
 		end
+		def hs(s, ac, x=nil)
+			hp(s, ac, x)+str(s, ac, x)
+		end
 		
 		def power(s, a=s, c=a.tap{a=s})
 			case @kind

--- a/lib/mgmg/recipe.rb
+++ b/lib/mgmg/recipe.rb
@@ -130,7 +130,7 @@ module Mgmg
 		def ir(**kw)
 			temp_opt(**kw).irep
 		end
-		%i|attack phydef magdef hp mp str dex speed magic atkstr atk_sd dex_as mag_das magic2 magmag pmdef|.each do |sym|
+		%i|attack phydef magdef hp mp str dex speed magic atkstr atk_sd dex_as mag_das magic2 magmag pmdef hs|.each do |sym|
 			define_method(sym) do |s, ac=s, x=false, **kw|
 				s, ac, x = correct_level(s, ac, x, temp_opt(**kw))
 				ir(**kw).method(sym).call(s, ac, x)

--- a/lib/mgmg/search.rb
+++ b/lib/mgmg/search.rb
@@ -369,6 +369,13 @@ module Mgmg
 		pa, pb = opt_a.irep.para_call(para, *sca), opt_b.irep.para_call(para, *scb)
 		if eb < ea || ( ea == eb && pa < pb )
 			a, b, opt_a, opt_b, sca, scb, ea, eb = b, a, opt_b, opt_a, scb, sca, eb, ea
+		elsif eb == ea && pa == pb
+			raise Mgmg::SearchCutException, "given recipes are equivalent at start target=#{start.comma3}"
+		end
+		scat, scbt = a.search(para, term, opt: opt_a), b.search(para, term, opt: opt_b)
+		eat, ebt = Mgmg.exp(*scat), Mgmg.exp(*scbt)
+		if eat < ebt || ( eat == ebt && opt_b.irep.para_call(para, *scbt) <= opt_a.irep.para_call(para, *scat) )
+			raise Mgmg::SearchCutException, "given recipes will never be reversed from start target=#{start.comma3} until term target=#{term.comma3}"
 		end
 		
 		loop do
@@ -419,13 +426,18 @@ module Mgmg
 		pa, pb = opt_a.irep.para_call(para, *sca), opt_b.irep.para_call(para, *scb)
 		if ea < eb || ( ea == eb && pb < pa )
 			a, b, opt_a, opt_b, sca, scb, ea, eb = b, a, opt_b, opt_a, scb, sca, eb, ea
+		elsif eb == ea && pa == pb
+			raise Mgmg::SearchCutException, "given recipes are equivalent at start target=#{start.comma3}"
 		end
+		
 		
 		loop do
 			loop do
 				foo = a.find_max(para, eb, opt: opt_a)
 				break if sca == foo
-				sca, pa = foo, opt_a.irep.para_call(para, *foo)
+				bar = opt_a.irep.para_call(para, *foo)
+				break if pa < bar
+				sca, pa = foo, bar
 				scb = b.search(para, pa, opt: opt_b)
 				foo = Mgmg.exp(*scb)
 				break if eb == foo

--- a/lib/mgmg/version.rb
+++ b/lib/mgmg/version.rb
@@ -1,3 +1,3 @@
 module Mgmg
-	VERSION = "1.6.0"
+	VERSION = "1.6.1"
 end

--- a/reference.md
+++ b/reference.md
@@ -1,7 +1,7 @@
 # リファレンス
 本ライブラリで定義される主要なメソッドを以下に解説します．
 
-## `String#to_recipe(para=:power, allow_over20: false, **kw)`，`Enumerable#to_recipe(para=:power, **kw)`
+## `String#to_recipe(para=:power, allow_over20: false, **kw)`，`Enumerable#to_recipe(para=:power, allow_over20: false, **kw)`
 レシピ文字列である`self`と，注目パラメータ`para`，オプション`Mgmg.option(**kw)`をセットにした[後述](#mgmgrecipe)の`Mgmg::Recipe`オブジェクトを生成して返します．デフォルト値としてセットされたパラメータを使用する以外は，レシピ文字列と同様に扱えます．
 
 `allow_over20`が偽の場合，レシピの☆を確認し，20を超える場合は，例外`Mgmg::Over20Error`を発生します．このチェックを抑制したい場合は，真にしてください．


### PR DESCRIPTION
- `Mgmg.#find_lowerbound`，`Mgmg.#find_upperbound`において，同値レシピを指定した場合などを例外とするように修正．
- `Enumerable#to_recipe`にも`allow_over20`キーワード引数を導入し，デフォルトで☆20を超えるレシピを含む場合に例外とするように修正．
- 実効HP(最大HP+腕力)を表す`Mgmg::Equip#hs`を追加．