### PR TITLE
Version 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,3 +184,8 @@
 - `Mgmg.#find_upperbound`のアルゴリズムに誤りがあり，大きく間違えた解を返していた問題を修正．
 - `Mgmg::IR#attack`等において，引数が`nil`(製作Lvを指定せず，多項式を返す)の場合に，例外となっていたバグを修正．
 - オブション`smith/armor/comp_max`のデフォルト値を10^9に変更．
+
+## 1.8.0 2022/11/14
+- オプション`comp_ext`を`fib_ext`に変更し，追加探索の範囲を修正．
+- オプション`smith/armor/comp_max`の扱い方を修正し，デフォルト値を10^5に変更．
+- `Enumerable#find_max`，`Mgmg.#find_lowerbound`のバグを修正．

--- a/lib/mgmg/option.rb
+++ b/lib/mgmg/option.rb
@@ -2,13 +2,13 @@ module Mgmg
 	class Option
 		Defaults = {
 			left_associative: true, include_system_equips: true,
-			smith_max: 1_000_000_000, armor_max: 1_000_000_000, comp_max: 1_000_000_000,
-			comp_ext: [0.1, 100, 10_000, 0.1]
+			smith_max: 100_000, armor_max: 100_000, comp_max: 100_000,
+			fib_ext: [4, 10]
 		}
 		def initialize(
 			left_associative: Defaults[:left_associative],
 			smith_min: nil, armor_min:nil, comp_min: nil, smith_max: Defaults[:smith_max], armor_max: Defaults[:armor_max], comp_max: Defaults[:comp_max],
-			comp_ext: Defaults[:comp_ext],
+			fib_ext: Defaults[:fib_ext],
 			magdef_maximize: true,
 			target_weight: 0, reinforcement: [], buff: nil,
 			irep: nil, cut_exp: Float::INFINITY,
@@ -21,7 +21,7 @@ module Mgmg
 			@smith_max = smith_max
 			@armor_max = armor_max
 			@comp_max = comp_max
-			@comp_ext = comp_ext
+			@fib_ext = fib_ext
 			@magdef_maximize = magdef_maximize
 			@target_weight = target_weight
 			@reinforcement = reinforcement
@@ -37,7 +37,7 @@ module Mgmg
 			@include_system_equips = include_system_equips
 			@system_equips_checked = false
 		end
-		attr_accessor :left_associative, :smith_min, :armor_min, :comp_min, :smith_max, :armor_max, :comp_max, :comp_ext
+		attr_accessor :left_associative, :smith_min, :armor_min, :comp_min, :smith_max, :armor_max, :comp_max, :fib_ext
 		attr_accessor :magdef_maximize, :target_weight, :reinforcement, :irep, :cut_exp, :include_system_equips, :system_equips_checked
 		def initialize_copy(other)
 			@left_associative = other.left_associative
@@ -47,7 +47,7 @@ module Mgmg
 			@smith_max = other.smith_max
 			@armor_max = other.armor_max
 			@comp_max = other.comp_max
-			@comp_ext = other.comp_ext
+			@fib_ext = other.fib_ext.dup
 			@magdef_maximize = other.magdef_maximize
 			@target_weight = other.target_weight
 			@reinforcement = other.reinforcement.dup

--- a/lib/mgmg/version.rb
+++ b/lib/mgmg/version.rb
@@ -1,3 +1,3 @@
 module Mgmg
-	VERSION = "1.7.0"
+	VERSION = "1.8.0"
 end

--- a/reference.md
+++ b/reference.md
@@ -130,9 +130,9 @@
 `opt`は，`comp_min`，`comp_max`，`left_associative`，`reinforcement`，`irep`を使用します．
 
 ## `String#search(para, target, opt: Mgmg.option())`
-合計経験値が最小となる鍛冶・防具製作Lvと道具製作Lvの組を探索します．道具製作Lvを決定変数として，`smith_search`の返り値との合計経験値を最小化する道具製作Lvをフィボナッチ探索で探索した後，得られた解 c の前後を探索し，最適化します．道具製作Lv c における合計経験値`exp`に対して，`exp+(exp*opt.comp_ext[0]).to_i.clamp(opt.comp_ext[1], opt.comp_ext[2])`を超えない範囲を探索します．この目的関数は単峰ではないため，フィボナッチ探索のみでは最適解が得られないことがあります．
+合計経験値が最小となる鍛冶・防具製作Lvと道具製作Lvの組を探索します．道具製作Lvを決定変数として，`smith_search`の返り値との合計経験値を最小化する道具製作Lvをフィボナッチ探索で探索した後，得られた解 c の前後を探索し，最適化します．このとき，道具製作Lv c における合計経験値`exp`，及びフィボナッチ探索で得られた最後の4点の経験値の最大値`exp2`に対して，`exp+(exp2-exp)*opt.fib_ext[0]`を超えない範囲を探索します．この目的関数は単峰ではないため，フィボナッチ探索のみでは最適解が得られないことがあります．
 
-その他は`String#smith_seach`と同様で，`opt`は，`String#smith_search`または`String#comp_search`で使われるすべてのパラメータと，`comp_ext`を使用します．
+その他は`String#smith_seach`と同様で，`opt`は，`String#smith_search`または`String#comp_search`で使われるすべてのパラメータと，`fib_ext`を使用します．
 
 ## `Enumerable#search(para, target, opt: Mgmg.option())`
 複数装備の組について，`para`の値が`target`以上となる最小経験値の`[鍛冶Lv，防具製作Lv，道具製作Lv]`を返します．
@@ -145,7 +145,7 @@
 ## `String#find_max(para, max_exp, opt: Mgmg.option())`
 経験値の合計が`max_exp`以下の範囲で，`para`の値が最大となる鍛冶・防具製作Lvと道具製作Lvからなる配列を返します．`para`の値が最大となる組が複数存在する場合，経験値が小さい方が優先されます．
 
-`String#search`と同様に，道具製作Lvをフィボナッチ探索で探索した後，得られた解 c の前後を探索し，最適化します．道具製作Lv c における最大の`para`値`p_c`に対して，`p_c-(p_c*opt.comp_ext[3]).ceil`を下回らない範囲を探索します．
+`String#search`と同様に，道具製作Lvをフィボナッチ探索で探索した後，得られた解 c の前後を探索し，最適化します．道具製作Lv c における最大の`para`値`p_c`，及びフィボナッチ探索で得られた最後の4点の`para`値の最小値`p_min`に対して，`p_c-(p_c-p_min)*opt.fib_ext[1]`を下回らない範囲を探索します．
 
 ## `Enumerable#find_max(para, max_exp, opt: Mgmg.option())`
 複数装備の組について，経験値の合計が`max_exp`以下の範囲で，`para`の値が最大となる鍛冶Lv，防具製作Lv，道具製作Lvからなる配列を返します．`para`の値が最大となる組が複数存在する場合，経験値が小さい方が優先されます．
@@ -454,8 +454,8 @@ alias として`*`があるほか`scalar(1.quo(value))`として`quo`，`/`，`s
 |smith_min|`recipe.min_level(target_weight)`|非対応|鍛冶Lvに関する探索範囲の最小値|`String#search`など|
 |armor_min|`recipe.min_level(*target_weight)[1]`|非対応|防具製作Lvに関する探索範囲の最小値|`Enumerable#search`など．`String`系では代わりに`smith_min`を使う|
 |comp_min|`recipe.min_comp`|非対応|道具製作Lvに関する探索範囲の最小値|`String#search`など|
-|smith_max, armor_max, comp_max|`1_000_000_000`|対応|各製作Lvの探索範囲の最大値|`String#search`など|
-|comp_ext|`[0.1, 100, 10_000, 0.1]`|対応|フィボナッチ探索後に追加探索を行う範囲|`String#search`など|
+|smith_max, armor_max, comp_max|`100_000`|対応|各製作Lvの探索範囲の最大値|`String#search`など|
+|fib_ext|`[4, 10]`|対応|フィボナッチ探索後に追加探索を行う範囲|`String#search`など|
 |target_weight|`0`|非対応|`smith_min`のデフォルト値計算に使う目標重量|`String#search`など|
 |magdef_maximize|`true`|非対応|目標を魔防最大(真)かコスト最小(偽)にするためのスイッチ|`String#phydef_optimize`|
 |reinforcement|`[]`|非対応|[前述](#mgmgequipreinforcearg)の`Mgmg::Equip#reinforce`による強化リスト|一部を除くすべてのメソッド|


### PR DESCRIPTION
- オプション`comp_ext`を`fib_ext`に変更し，追加探索の範囲を修正．
- オプション`smith/armor/comp_max`の扱い方を修正し，デフォルト値を10^5に変更．
- `Enumerable#find_max`，`Mgmg.#find_lower